### PR TITLE
Add formspree to contact form

### DIFF
--- a/app/index.html
+++ b/app/index.html
@@ -224,19 +224,16 @@
                     </div>
                   </div>
                   <div class="col-md-6">
-                    <form>
+                    <form action="https://formspree.io/zoohouse.info@gmail.com" method="POST">
                       <div class="form-group has-feedback left">
-                        <input type="text" class="form-control" placeholder="NAME">
-                        <i class="fa fa-user form-control-feedback"></i>
-                      </div>
-                      <div class="form-group has-feedback left">
-                        <input type="email" class="form-control" placeholder="Email">
+                        <input type="email" name="_replyto" class="form-control" placeholder="Email">
                         <i class="fa fa-envelope-o form-control-feedback"></i>
                       </div>
                       <div class="form-group has-feedback left">
-                        <textarea class="form-control" rows="7" placeholder="MESSAGE"></textarea>
+                        <textarea name="message" class="form-control" rows="7" placeholder="MESSAGE"></textarea>
                         <i class="fa fa-pencil-square-o form-control-feedback"></i>
                       </div>
+                      <input type="text" name="_gotcha" style="display:none" />
                       <button class="btn btn-primary btn-lg pull-right" type="submit">SUBMIT</button>
                     </form>
                   </div>


### PR DESCRIPTION
Use formspree for our contact form. We need to verify the email first though. @dannyeng 
